### PR TITLE
showImmediately config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Please create an issue if you want to suggest a better (more confortable) shortc
 ## Current Drawbacks
 - For now, it only displays each attributes's name and type. (If you have an idea of how to show the `:limit`, `:default`, etc options of each column, make an issue with the idea)
 - It works by reading the class name of a ruby file, so if the model doesn't have the name of the table (for example, when using simple model inheritance or setting the table name with `self.table_name=`), it won't work.
+
+## TODO
+- Make tests.
+- Fix the drawbacks listed above.

--- a/lib/schema-editors.coffee
+++ b/lib/schema-editors.coffee
@@ -1,0 +1,35 @@
+class SchemaEditors
+  constructor: (@subscriptions)->
+    @editors = []
+
+  add: (editor, active = true) ->
+    if @exclude(editor)
+      @editors.push(editor: editor, active: active)
+      @subscriptions.add editor.onDidDestroy =>
+        @editors = @editors.filter ({editor}) => editor.alive
+
+  addOrActivate: (editor) ->
+    @add(editor)
+    @activate(editor)
+
+  exclude: (editor) ->
+    @find(editor) == null
+
+  include: (editor) ->
+    !@exclude(editor)
+
+  includeActive: (editor) ->
+    editorObject = @find(editor)
+    editorObject && editorObject.active
+
+  find: (editorToLook) ->
+    founds = @editors.filter(({editor}) => editor == editorToLook)
+    if founds.length > 0 then founds[0] else null
+
+  activate: (editor) ->
+    @find(editor)?.active = true
+
+  deactivate: (editor) ->
+    @find(editor)?.active = false
+
+module.exports = SchemaEditors


### PR DESCRIPTION
This keep tracks of the editors to be able to show/hide the sidebar for each editor independently. It also adds the option `showImmediately` (`true` by default) to give the option to initiate a new editor without the sidebar.